### PR TITLE
Fix filename casing for case-sensitive systems

### DIFF
--- a/Engine/src/Settings.cs
+++ b/Engine/src/Settings.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
-using System.Xml.Linq;
-using Microsoft.Extensions.Configuration;
 
 namespace Civ2engine
 {
@@ -68,12 +65,13 @@ namespace Civ2engine
             }
         }
 
-        public static bool IsValidRoot(string? civ2Path)
+        public static bool IsValidRoot(string civ2Path)
         {
             try
             {
                 return !string.IsNullOrWhiteSpace(civ2Path) && Directory.Exists(civ2Path) &&
-                       Directory.GetFiles(civ2Path, RulesFile).Length > 0;
+                       (File.Exists(Path.Combine(civ2Path, RulesFile)) ||
+                        File.Exists(Path.Combine(civ2Path, RulesFile.ToUpper())));
             }
             catch
             {

--- a/RaylibUI/Sounds/Sound.cs
+++ b/RaylibUI/Sounds/Sound.cs
@@ -106,7 +106,7 @@ namespace RaylibUI
 
     public SoundData? PlayCIV2DefaultSound(string soundName, bool loop = false)
     {
-      var pth = Utils.GetFilePath(soundName, Settings.SearchPaths.Select(p=>Path.Combine(p,"SOUND")), "wav");
+      var pth = Utils.GetFilePath(soundName, Settings.SearchPaths.Select(p=>Path.Combine(p,"Sound")), "wav");
 
       return pth != null ? PlaySound(pth, loop) : null;
     }


### PR DESCRIPTION
I'm running on Linux and I'm using the Civ2 gold iso and got that some files couldn't be loaded due to different casing.