### PR TITLE
CTRL+ N to EndTurn

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/RaylibUI/bin/Debug/net6.0/RaylibUI.dll",
+            "program": "${workspaceFolder}/RaylibUI/bin/Debug/net8.0/RaylibUI.dll",
             "args": [],
             "cwd": "${workspaceFolder}/RaylibUI",
             "console": "internalConsole",
@@ -20,7 +20,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/RaylibUI/bin/Debug/net6.0/RaylibUI",
+            "program": "${workspaceFolder}/RaylibUI/bin/Debug/net8.0/RaylibUI",
             "args": [],
             "cwd": "${workspaceFolder}/RaylibUI",
             "console": "internalConsole",
@@ -32,7 +32,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/RaylibUI/bin/Debug/net6.0/RaylibUI.Mac",
+            "program": "${workspaceFolder}/RaylibUI/bin/Debug/net8.0/RaylibUI.Mac",
             "args": [],
             "cwd": "${workspaceFolder}/RaylibUI",
             "console": "internalConsole",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-Civilization II (original/Multiplayer Gold Edition & Test of Time remake) clone in .NET 6.0 using [C# bindings](https://github.com/ChrisDill/Raylib-cs) of [Raylib](https://www.raylib.com/) for Win/Linux/Mac.
+Civilization II (original/Multiplayer Gold Edition & Test of Time remake) clone in .NET 8.0 using [C# bindings](https://github.com/ChrisDill/Raylib-cs) of [Raylib](https://www.raylib.com/) for Win/Linux/Mac.
 
 Folders:
 - Engine = the Civ2 logic (core) code
@@ -34,7 +34,7 @@ Goals:
 
 # Running the game
 
-Download the .NET 6.0 SDK. The easiest way is to run the game with Visual Studio or VSCode.
+Download the .NET 8.0 SDK. The easiest way is to run the game with Visual Studio or VSCode.
  
 You have to point to RaylibUI folder then build it.
 

--- a/RaylibUI/RunGame/Commands/EndTurn.cs
+++ b/RaylibUI/RunGame/Commands/EndTurn.cs
@@ -1,7 +1,5 @@
-using System.Diagnostics.CodeAnalysis;
 using Model;
 using Model.Dialog;
-using Model.Images;
 using Model.Menu;
 using Raylib_CSharp.Interact;
 

--- a/RaylibUI/RunGame/Commands/EndTurn.cs
+++ b/RaylibUI/RunGame/Commands/EndTurn.cs
@@ -18,7 +18,7 @@ public class EndTurn : IGameCommand
 
     public string Id => CommandIds.EndTurn;
     
-    public Shortcut[] ActivationKeys { get; set; } = { new (KeyboardKey.Enter), new (KeyboardKey.KpEnter)};
+    public Shortcut[] ActivationKeys { get; set; } = { new (KeyboardKey.Enter), new (KeyboardKey.KpEnter), new(KeyboardKey.N, ctrl: true)};
     public CommandStatus Status { get; private set; }
 
     public bool Update()


### PR DESCRIPTION
Add the CTRL+N shortcut to end the player turn, in line with the already working Order->End Player Turn menu option. Note that in the original game, ending a turn using the Enter key behaves slightly different to ending a turn using the menu, so these should be made distinct at some point.

Also added a few tidies from the repository's recent .NET 8 update which I needed to debug it locally.