### PR TITLE
GenerateRulesets uses Utils.GetFilePath helper instead of raw paths

### DIFF
--- a/Civ2Gold/Civ2GoldInterface.cs
+++ b/Civ2Gold/Civ2GoldInterface.cs
@@ -636,7 +636,7 @@ public class Civ2GoldInterface : Civ2Interface
     
     protected override IEnumerable<Ruleset> GenerateRulesets(string path, string title)
     {
-        var rules = path + Path.DirectorySeparatorChar + "rules.txt";
+        var rules = Utils.GetFilePath("rules.txt", [path]);
         if (File.Exists(rules))
         {
             yield return new Ruleset(title, new Dictionary<string, string>
@@ -646,11 +646,11 @@ public class Civ2GoldInterface : Civ2Interface
 
             foreach (var subdirectory in Directory.EnumerateDirectories(path))
             {
-                var scnRules = Path.Combine(subdirectory, "rules.txt");
+                var scnRules = Utils.GetFilePath("rules.txt", [subdirectory]);
                 if (File.Exists(scnRules))
                 {
 
-                    var game = subdirectory + Path.DirectorySeparatorChar + "game.txt";
+                    var game = Utils.GetFilePath("game.txt", [subdirectory]);
                     var name = "";
                     if (File.Exists(game))
                     {

--- a/Civ2TOT/TestOfTimeInterface.cs
+++ b/Civ2TOT/TestOfTimeInterface.cs
@@ -97,7 +97,7 @@ public class TestOfTimeInterface : Civ2Interface
         var originalPath = Path.Combine(path, original);
 
         var originalERxists = Directory.Exists(originalPath);
-        var rules = originalPath + Path.DirectorySeparatorChar + "rules.txt";
+        var rules = Utils.GetFilePath("rules.txt", [originalPath]);
         if (File.Exists(rules))
         {
             yield return new Ruleset(title, new Dictionary<string, string>
@@ -107,10 +107,10 @@ public class TestOfTimeInterface : Civ2Interface
 
             foreach (var subdirectory in Directory.EnumerateDirectories(path))
             {
-                var scnRules = Path.Combine(subdirectory, "rules.txt");
+                var scnRules = Utils.GetFilePath("rules.txt", [subdirectory]);
                 if (File.Exists(scnRules))
                 {
-                    var game = subdirectory + Path.DirectorySeparatorChar + "game.txt";
+                    var game = Utils.GetFilePath("game.txt", [subdirectory]);
                     var name = "";
                     if (File.Exists(game))
                     {


### PR DESCRIPTION
In particular this fixes case-sensitivity issues when opening RULES.TXT on Linux. (See https://github.com/axx0/Civ2-clone/issues/142)

I manually tested this change in MGE with 'RULES.TXT' on a Linux system. Prior to this commit, the game crashed on startup. With this change, the game launches and I can launch a new game or load scenarios without any crashes.

I don't have a copy of the ToT datafiles to test with right now, so the changes in TestOfTimeInterface.cs are untested.