### PR TITLE
CitiesBuiltSoFar counters loaded from save game into Civilization objects

### DIFF
--- a/Engine/src/OriginalSaves/Read.ClassicSav.cs
+++ b/Engine/src/OriginalSaves/Read.ClassicSav.cs
@@ -1014,11 +1014,13 @@ public class Read
         //DATA FOR FINDING NEXT CITY NAME
         //=========================
         int ofsetTc = ofsetC + multipl * numberOfCities;
-
-        var citiesBuiltSofar = new byte[21];
-        for (int civId = 0; civId < 21; civId++)
+        foreach (Civilization civ in objects.Civilizations)
         {
-            citiesBuiltSofar[civId] = bytes[ofsetTc + 3 * civId + 1];
+            if (civ.PlayerType != PlayerType.Barbarians)
+            {
+                int ofsetTcThisCiv = ofsetTc + 3 * civ.TribeId + 1;
+                civ.CitiesBuiltSoFar = bytes[ofsetTcThisCiv];
+            }
         }
         #endregion
         #region Other info

--- a/Engine/src/UnitActions/CityActions.cs
+++ b/Engine/src/UnitActions/CityActions.cs
@@ -14,7 +14,7 @@ namespace Civ2engine.UnitActions
     {
         public static string GetCityName(Civilization civ , IGame game)
         {
-            var cityCount = game.History.TotalCitiesBuilt(civ.Id);
+            var cityCount = civ.CitiesBuiltSoFar;
             var names = game.CityNames;
             var tribe = civ.TribeName.ToUpperInvariant();
             var civCityList = names[names.ContainsKey(tribe) ? tribe : "EXTRA"];
@@ -44,6 +44,7 @@ namespace Civ2engine.UnitActions
             tile.CityHere = city;
             game.AllCities.Add(tile.CityHere);
             unit.Owner.Cities.Add(tile.CityHere);
+            unit.Owner.CitiesBuiltSoFar++;
 
             game.SetImprovementsForCity(city);
             

--- a/Model/Core/Civilization.cs
+++ b/Model/Core/Civilization.cs
@@ -40,7 +40,12 @@ namespace Civ2engine
         public int[] CasualtiesPerUnitType { get; set; }
 
         public List<City> Cities { get; } = new();
-        
+        /**
+         * CitiesBuiltSoFar is not necessarily the same as Cities.Count;
+         * it will include cities lost to other civs or destroyed.
+         */
+        public int CitiesBuiltSoFar { get; set; }
+
         public PlayerType PlayerType { get; set; }
         public int PowerRating { get; set; }
         public int PowerRank { get; set; }


### PR DESCRIPTION
This way the counter is available in the BuildCity method for its intended purpose of suggesting the right city name from CITIES.TXT.

Manually tested in MGE with a vanilla SAV file and a few scenarios.

This fixes https://github.com/axx0/Civ2-clone/issues/144