### PR TITLE
bugfix: load new-style SAV with 0-improvement cities without crashing

### DIFF
--- a/Engine/src/SaveLoad/GameSerializer.cs
+++ b/Engine/src/SaveLoad/GameSerializer.cs
@@ -245,8 +245,15 @@ public class GameSerializer
         
         tile.CityHere = city;
 
-        for (var improvementNo = 0; improvementNo < cityData.Improvements.Length && improvementNo < rules.Improvements.Length -1; improvementNo++)
-            if (cityData.Improvements[improvementNo]) city.AddImprovement(rules.Improvements[improvementNo+1]);
+        if (cityData.Improvements != null)
+        {
+            for (var improvementNo = 0;
+                 improvementNo < cityData.Improvements.Length && improvementNo < rules.Improvements.Length - 1;
+                 improvementNo++)
+                if (cityData.Improvements[improvementNo])
+                    city.AddImprovement(rules.Improvements[improvementNo + 1]);
+        }
+
         return city;
     }
 


### PR DESCRIPTION
A city's improvements in JsonCityData is serialized as a boolean array, and as an optimization all the trailing "falses" are cut off. A city with no improvements is not written as an empty array - the json object doesn't have the improvements key at all. (Example at the bottom of this commit message.)

HydrateCity would try to iterate over the (null) array cityData.Improvements and then crash with a null reference.

Example of such a save file:

```
> cat xe_ad180_new_style.sav.json | jq ".game.cities[] | .Name,.Improvements"

...
[
  "Rome",
  [
    false, true, false, false, true
  ]
]
[
  "London",
  [
    false, true, false, false, true
  ]
]
[
  "Hamburg",
  null
]
...
```

To reproduce:

* Open xe_a80_old_style.sav (may need to remove the .txt extension, i added that so github lets me attach it)
* Save it (you should get a file mostly identical to the xe_ad180_new_style.sav.json)
* Open xe_ad180_new_style.sav.json

[xe_ad180_new_style.sav.json](https://github.com/user-attachments/files/23152967/xe_ad180_new_style.sav.json)
[xe_a180_old_style.sav.txt](https://github.com/user-attachments/files/23152968/xe_a180_old_style.sav.txt)
