### PR TITLE
Keep track of city count using History instead of per-Civ counter

### DIFF
--- a/Engine/src/Game.cs
+++ b/Engine/src/Game.cs
@@ -24,7 +24,7 @@ namespace Civ2engine
 
         public IHistory History
         {
-            get { return _history ??= new History(this); }
+            get { return _history ??= HistoryUtils.ReconstructHistory(this); }
         }
 
         public List<Civilization> AllCivilizations { get; } = new();
@@ -127,9 +127,7 @@ namespace Civ2engine
             var order = Rules.Orders.FirstOrDefault(t => t.Type == unitOrder);
             return order != null ? order.Name : Labels.For(LabelIndex.NoOrders);
         }
-
         
-
         public void ConnectPlayer(IPlayer player)
         {
             var id = player.Civilization.Id;

--- a/Engine/src/History/History.cs
+++ b/Engine/src/History/History.cs
@@ -10,7 +10,6 @@ namespace Civ2engine
         private readonly Game _game;
 
         private List<HistoryEvent> _events = new();
-        
 
         internal History(Game game)
         {

--- a/Engine/src/History/HistoryEventType.cs
+++ b/Engine/src/History/HistoryEventType.cs
@@ -5,4 +5,6 @@ namespace Civ2engine.Advances
         AdvanceDiscovered,
         CityBuilt
     }
+    // Breadcrumb: if you add a new HistoryEvent here, consider also updating
+    // HistoryUtils.ReconstructHistory to support 'backfilling' from legacy SAV/SCN files.
 }

--- a/Engine/src/History/HistoryUtils.cs
+++ b/Engine/src/History/HistoryUtils.cs
@@ -1,0 +1,37 @@
+namespace Civ2engine;
+
+public static class HistoryUtils
+{
+    /*
+     * Reconstructs an artificial History based on an initial game state.
+     *
+     * When creating a new Game, this ensures that initial technologies are recorded as discovered on turn 1.
+     *
+     * When creating a Game from a Legacy SAV/SCN file:
+     * The legacy SAV/SCN format does not persist turn-by-turn historical information,
+     * so this method allows events like CityBuilt and AdvanceDiscovered to be recorded in History.
+     * But, as a compromise all events will appear to have happened on the turn that the game was loaded.
+     */
+    public static History ReconstructHistory(Game game)
+    {
+        History history = new History(game);
+        foreach (var city in game.AllCities)
+        {
+            history.CityBuilt(city);
+        }
+        foreach (var civ in game.AllCivilizations)
+        {
+            if (civ.Advances != null)
+            {
+                for (int advanceNumber = 0; advanceNumber < civ.Advances.Length; advanceNumber++)
+                {
+                    if (civ.Advances[advanceNumber])
+                    {
+                        history.AdvanceDiscovered(advanceNumber, civ.Id);
+                    }
+                }
+            }
+        }
+        return history;
+    }
+}

--- a/Engine/src/OriginalSaves/Read.ClassicSav.cs
+++ b/Engine/src/OriginalSaves/Read.ClassicSav.cs
@@ -1019,7 +1019,6 @@ public class Read
             if (civ.PlayerType != PlayerType.Barbarians)
             {
                 int ofsetTcThisCiv = ofsetTc + 3 * civ.TribeId + 1;
-                civ.CitiesBuiltSoFar = bytes[ofsetTcThisCiv];
             }
         }
         #endregion

--- a/Engine/src/UnitActions/CityActions.cs
+++ b/Engine/src/UnitActions/CityActions.cs
@@ -14,13 +14,13 @@ namespace Civ2engine.UnitActions
     {
         public static string GetCityName(Civilization civ , IGame game)
         {
-            var cityCount = civ.CitiesBuiltSoFar;
+            var cityCount = game.History.TotalCitiesBuilt(civ.Id);
             var names = game.CityNames;
             var tribe = civ.TribeName.ToUpperInvariant();
             var civCityList = names[names.ContainsKey(tribe) ? tribe : "EXTRA"];
             if (cityCount < civCityList?.Count)
             {
-                return civCityList[cityCount];
+                return civCityList[cityCount + 1];
             }
             
             return "Dummy Name";
@@ -44,7 +44,6 @@ namespace Civ2engine.UnitActions
             tile.CityHere = city;
             game.AllCities.Add(tile.CityHere);
             unit.Owner.Cities.Add(tile.CityHere);
-            unit.Owner.CitiesBuiltSoFar++;
 
             game.SetImprovementsForCity(city);
             

--- a/Model/Core/Civilization.cs
+++ b/Model/Core/Civilization.cs
@@ -40,11 +40,6 @@ namespace Civ2engine
         public int[] CasualtiesPerUnitType { get; set; }
 
         public List<City> Cities { get; } = new();
-        /**
-         * CitiesBuiltSoFar is not necessarily the same as Cities.Count;
-         * it will include cities lost to other civs or destroyed.
-         */
-        public int CitiesBuiltSoFar { get; set; }
 
         public PlayerType PlayerType { get; set; }
         public int PowerRating { get; set; }


### PR DESCRIPTION
This partially addresses https://github.com/axx0/Civ2-clone/issues/147 - we are not yet storing history for *all* 21 possible tribes, but sets us up to do so in the future.

The trick is 'backfilling' history when loading from a legacy SAV game. While I was here i'm also 'backfills' discovered advances in the History structure too.

I did manual tests similar to previous commits, with both a MGE legacy SAV and a new-style json SAV file, to verify that the new city dialog suggests the correct next-city name from CITIES.TXT.