### PR TITLE
Implement 'Change Money' cheat dialog

### DIFF
--- a/Civ2Gold/Civ2GoldInterface.cs
+++ b/Civ2Gold/Civ2GoldInterface.cs
@@ -376,7 +376,7 @@ public class Civ2GoldInterface : Civ2Interface
                 new MenuElement("Destro&Y All Units At Cursor|Ctrl+Shift+D",
                     new Shortcut(KeyboardKey.D, ctrl: true, shift: true), KeyboardKey.Y),
                 new MenuElement("Change Money|Shift+F9", new Shortcut(KeyboardKey.F9, shift: true),
-                    KeyboardKey.Null),
+                    KeyboardKey.Null, CheatChangeMoneyCommand),
                  new MenuElement("-", Shortcut.None, KeyboardKey.Null),
                new MenuElement("Edit Unit|Ctrl+Shift+U", new Shortcut(KeyboardKey.U, ctrl: true, shift: true),
                     KeyboardKey.Null),

--- a/Civ2TOT/TestOfTimeInterface.cs
+++ b/Civ2TOT/TestOfTimeInterface.cs
@@ -462,7 +462,7 @@ public class TestOfTimeInterface : Civ2Interface
                 new MenuElement("Destro&Y All Units At Cursor|Ctrl+Shift+D",
                     new Shortcut(KeyboardKey.D, ctrl: true, shift: true), KeyboardKey.Y),
                 new MenuElement("Change Money|Shift+F9", new Shortcut(KeyboardKey.F9, shift: true),
-                    KeyboardKey.Null),
+                    KeyboardKey.Null, CheatChangeMoneyCommand),
                 new MenuElement("-", Shortcut.None, KeyboardKey.Null),
                 new MenuElement("Edit Unit|Ctrl+Shift+U", new Shortcut(KeyboardKey.U, ctrl: true, shift: true),
                     KeyboardKey.Null),

--- a/Model/Menu/CommandIds.cs
+++ b/Model/Menu/CommandIds.cs
@@ -45,4 +45,5 @@ public static class CommandIds
     public const string LoadMap = "LOAD_MAP";
     
     public const string CheatRevealMapCommand = "CHEAT_REVEAL_MAP";
+    public const string CheatChangeMoneyCommand = "CHEAT_CHANGE_MONEY";
 }

--- a/RaylibUI/RunGame/Commands/Cheat/ChangeMoney.cs
+++ b/RaylibUI/RunGame/Commands/Cheat/ChangeMoney.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics;
+using Civ2engine;
+using Microsoft.VisualBasic.CompilerServices;
+using Model.Core;
+using Model.Interface;
+using Model.Menu;
+using Raylib_CSharp.Interact;
+using Point = Model.Point;
+
+namespace RaylibUI.RunGame.Commands.Cheat;
+
+public class ChangeMoney(GameScreen gameScreen) : AlwaysOnCommand(gameScreen, CommandIds.CheatChangeMoneyCommand, [new Shortcut(KeyboardKey.F9, shift: true)])
+{
+    private CivDialog? _selectTribeDialog;
+    private CivDialog? _enterNewMoneyDialog;
+    private const string NewTreasury = "New Treasury";
+    private Civilization? targetCiv;
+
+    public override void Action()
+    {
+        var allLabel = Labels.For(LabelIndex.EntireMap);
+        var noSpecial = Labels.For(LabelIndex.NoSpecialView);
+        
+        _selectTribeDialog = new CivDialog(GameScreen.Main, new PopupBox
+        {
+            Title = "Pick A Player",
+            Options = GameScreen.Game.AllCivilizations
+                .FindAll(c=>c.PlayerType != PlayerType.Barbarians)
+                .Select(c=>c.Adjective)
+                .ToArray(),
+            Button = [Labels.Ok, Labels.Cancel]
+        }, new Point(0,0), HandleClickSelectTribe );
+        
+        GameScreen.ShowDialog(_selectTribeDialog);
+    }
+
+    private void HandleClickSelectTribe(string button, int selection, IList<bool>? arg3, IDictionary<string, string>? arg4)
+    {
+        if (button == Labels.Ok)
+        {
+            var civId = selection + 1;
+            targetCiv = gameScreen.Game.AllCivilizations.Find(civ => civ.Id == civId && civ.PlayerType != PlayerType.Barbarians);
+            Debug.Assert(targetCiv != null, nameof(targetCiv) + " != null");
+
+            _enterNewMoneyDialog = BuildChangeMoneyDialog(targetCiv.Money, targetCiv.Adjective);
+            GameScreen.CloseDialog(_selectTribeDialog);
+            GameScreen.ShowDialog(_enterNewMoneyDialog);
+        }
+        else
+        {
+            GameScreen.CloseDialog(_selectTribeDialog);
+        }
+    }
+
+    private CivDialog BuildChangeMoneyDialog(int currentMoney, String adjective)
+    {
+        String dialogTitle = $"Change {adjective} Treasury";
+        String subtitle = $"{adjective} treasury currently {currentMoney} Gold";
+        
+        TextBoxDefinition textBox = new TextBoxDefinition
+        {
+            Index = 0,
+            InitialValue = currentMoney.ToString(),
+            Description = "New treasury:",
+            MinValue = 0,
+            Name = NewTreasury,
+            Width = 225
+        };
+
+        PopupBox popupBox = new PopupBox
+        {
+            Title = dialogTitle,
+            Button = [Labels.Ok, Labels.Cancel],
+            Text = new List<string> { subtitle },
+            LineStyles = new List<TextStyles> { TextStyles.LeftOwnLine }
+        };
+
+        return new CivDialog(
+            GameScreen.Main, popupBox, new Point(0, 0), DoChangeMoney,
+            textBoxDefs: new List<TextBoxDefinition> { textBox });
+    }
+
+    private void DoChangeMoney(string button, int selectedIndex, IList<bool>? check,
+        IDictionary<string, string>? textBoxes)
+    {
+        if (textBoxes != null && button == Labels.Ok && textBoxes.TryGetValue(NewTreasury, out var newMoney) &&
+            targetCiv != null)
+        {
+            targetCiv.Money = IntegerType.FromString(newMoney);
+        }
+        GameScreen.CloseDialog(_enterNewMoneyDialog);
+        GameScreen.StatusPanel.Update();
+    }
+}


### PR DESCRIPTION
Wanted to cut my teeth on some of the UX code so knocked out one of the simpler cheat dialogs.

---

This is a two-part dialog; first a civ-picker and then a textbox to enter the new treasury value.

I diverged slightly from how original Civ2 displays the current treasury value, which is like "Indian treasury currently {1000$}." , I instead format this as "Indian treasury currently 1000 Gold".

* Tested opening dialog, both by clicking in the menu in civ2-gold UI and pressing shift-F9
* Changes to active player's money is reflected in the status pane

<img width="1308" height="866" alt="Screenshot from 2025-11-25 21-38-21" src="https://github.com/user-attachments/assets/c891f033-f58b-47ba-be48-58163e55cd35" />

<img width="1308" height="866" alt="Screenshot from 2025-11-25 21-39-11" src="https://github.com/user-attachments/assets/656d8c19-ae2a-4b41-99c7-335a59fb6e75" />
