### PR TITLE
IControl has separate hooks for OnCharPressed and OnKeyPressed

### DIFF
--- a/RaylibUI/BasicTypes/BaseControl.cs
+++ b/RaylibUI/BasicTypes/BaseControl.cs
@@ -84,6 +84,11 @@ public abstract class BaseControl : IControl
         return false;
     }
 
+    public virtual bool OnCharPressed(Char charPressed)
+    {
+        return false;
+    }
+
     public virtual void OnMouseMove(Vector2 moveAmount)
     {
         if (!_visible) return;

--- a/RaylibUI/BasicTypes/BaseScreen.cs
+++ b/RaylibUI/BasicTypes/BaseScreen.cs
@@ -59,6 +59,15 @@ public abstract class BaseScreen : BaseLayoutController, IScreen
 
     private void ControlEvents(IControlLayout layoutController)
     {
+        // Handle up to 16 characters per frame
+        for (int i = 0; i < 16; i++)
+        {
+            var charPressed = Convert.ToChar(Input.GetCharPressed());
+            if (charPressed > char.MinValue)
+            {
+                layoutController.Focused?.OnCharPressed(charPressed);
+            }
+        }
         foreach (var key in _keys)
         {
             if (!Input.IsKeyPressed(key)) continue;

--- a/RaylibUI/BasicTypes/Controls/TextBox.cs
+++ b/RaylibUI/BasicTypes/Controls/TextBox.cs
@@ -105,6 +105,22 @@ public class TextBox : BaseControl
         return _minWidth;
     }
 
+    /**
+     * Note that TextBox implements BOTH onCharPressed and onKeyPressed.
+     * onCharPressed captures the user's inputted text,
+     * while onKeyPressed handles editing/navigation within the textbox.
+     */
+    public override bool OnCharPressed(char charPressed)
+    {
+        if (charPressed <= char.MinValue)
+        {
+            return false;
+        }
+        _text = _text.Insert(_editPosition, charPressed.ToString());
+        SetEditPosition(_editPosition + 1);
+        return true;
+    }
+
     public override bool OnKeyPressed(KeyboardKey key)
     {
         switch (key)
@@ -147,16 +163,6 @@ public class TextBox : BaseControl
                 if (_acceptAction != null)
                 {
                     _acceptAction(_text);
-                    return true;
-                }
-
-                break;
-            default:
-                var charPressed = Input.GetCharPressed();
-                if (charPressed > 0)
-                {
-                    _text = _text.Insert(_editPosition, Convert.ToChar(charPressed).ToString());
-                    SetEditPosition(_editPosition + 1);
                     return true;
                 }
 

--- a/RaylibUI/BasicTypes/IControl.cs
+++ b/RaylibUI/BasicTypes/IControl.cs
@@ -18,8 +18,20 @@ public interface IControl
 
     bool CanFocus { get; }
     IList<IControl>? Children { get; }
-
+    
+    /**
+     * Accepts a keystroke. Keystrokes are used for shortcuts and keyboard-based navigation.
+     * Keep in mind that keystrokes are not the same as chars; for example LEFT_ARROW is not
+     * associated with any char, and KeyboardKey.S may be used for entering lowercase 's' or uppercase 'S'.
+     */
     bool OnKeyPressed(KeyboardKey key);
+    /**
+     * Accepts a UTF-16 character.
+     * Keep in mind that keystrokes are not the same as chars; for example LEFT_ARROW is not
+     * associated with any char, and KeyboardKey.S may be used for entering lowercase 's' or uppercase 'S'.
+     * This is used by textboxes; most Controls should hook into OnKeyPressed rather than OnCharPressed.
+     */
+    bool OnCharPressed(char charPressed);
     void OnMouseMove(Vector2 moveAmount);
     void OnMouseLeave();
     void OnMouseEnter();


### PR DESCRIPTION
Fixes: https://github.com/axx0/Civ2-clone/issues/151 "None of the text box dialogs allow input [on some systems]"

I believe the nature of the race condition is that Raylib's KeyPressed/CharPressed events from the same keystroke can happen in different frames. Specifically I observed that GetCharPressed usually "lands" a frame later.

Prior to this commit, input into Textboxes happens in the OnKeyPressed hook; i.e. only if both KeyPressed and CharPressed are simultaneously non-null, which seems to almost never happen on my system!

---

# Manual testing done

### main menu

- Can click to select items
- Arrow keys and numpad move between items in single-column lists
- Arrow keys and numpad move between items in multi-column lists, including horizontal movement between columns
- Enter is equivalent to "OK"
- Esc is equivalent to "Cancel"

### text boxes

- Backspace and delete work
- Left/Right arrow keys move cursor
- Tab alternates between elements
- Can type in custom king/civ name - verify that inputs like 'abcdZXCV1234%^&*' are accepted

### in-game

- shift-F2 opens Reveal Map cheat dialog
- CTRL-s opens save game dialog
- CTRL-q opens quit game dialog
- z/x to zoom in and out
- ctrl-z, shift-z, shift-x, ctrl-x
- arrow keys moves unit
- numpad moves unit

test the following build orders with settler:

- build (i)rrigation
- clean (p)ollution
- build (r)oad
- build (f)ort
- (s)leep
- space to skip turn
- (b)uild city; verify can enter city name

city window:

- test scrolling through a city production
- esc exits the city window

dropdowns:

- escape exits
- enter proceeds with highlighted choice
- typing hotkeys skips to that item in the list