### PR TITLE
bugfix: wire up checkbox action correctly

### DIFF
--- a/RaylibUI/BasicTypes/Panel/OptionsPanel.cs
+++ b/RaylibUI/BasicTypes/Panel/OptionsPanel.cs
@@ -143,7 +143,6 @@ public class OptionsPanel : BaseControl
         {
             var entry = new OptionControl(_controller, this, _texts[i], i,
                     CheckboxStates?[i] ?? false, i < (_icons?.Length ?? 0) ? [_icons[i]] : images);
-            entry.Selected = SetSelectedOption;
             _optionControls.Add(entry);
         }
 
@@ -172,6 +171,7 @@ public class OptionsPanel : BaseControl
         var optionAction = _isCheckbox ? (Action<OptionControl>)ToggleCheckBox : SetSelectedOption;
         foreach (var option in _optionControls)
         {
+            option.Selected = optionAction;
             Controls.Add(option);
         }
 


### PR DESCRIPTION
Noticed checkbox dialogs were broken, not sure if this was just missed in the big UI refactor!

OptionsPanels has two different handlers; `SetSelectedOption` used for radio buttons and `ToggleCheckBox` used for checkbox-style menus

`var optionAction = ...` was correctly assigned but never used; instead the `entry.Selected` hook was hard-coded to SetSelectedOption in line 146.

so the fix was straight-forward.

<img width="1277" height="775" alt="image" src="https://github.com/user-attachments/assets/0f92ef9a-a7e4-4db8-85d7-6cfe4eb547f3" />
